### PR TITLE
Log file rotation improvements

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -38,10 +38,10 @@ private:
     // log.2.txt -> log.3.txt
     // log.3.txt -> delete
     void rotate_();
+    void recover_();
 
-    // delete the target if exists, and rename the src file  to target
-    // return true on success, false otherwise.
-    bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
+    // throw exception if rename fails a second time
+    void rename_file_(const filename_t &src_filename, const filename_t &target_filename);
 
     filename_t base_filename_;
     std::size_t max_size_;


### PR DESCRIPTION
### Motivation

When a service is restarted it is possible renaming a log file fails because of Windows file-locking or receive an "access denied". (see Issue #987) I have observed losing a log file, because the `rename_file_` removes the target first.

The implementation of `rename_file_` always removes the target before renaming source to target. Removing the target is only necessary to replace the oldest file. 

The goal of this change it to:
1. eliminate the remove from `rename_file_`
2. make removing the oldest file an explicit action.

### Description

Proposed solution to make rotation more robust
This change deals with a failed rename, but does not prevent it.

1. Changed rename_file_ so it doesn't delete the target.

2. Changed rotate_ so it removes the last file before starting the rename loop.

3. When rename fails the rotation stops and leaves gaps between the files.

- Added `recover_` function to deal with gaps caused by a failed rename.
- In case of gaps, move files in a single pass. Don't move the oldest file.
- If gaps still exist after first pass, then those will be dealt with next time `recover_` runs

- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
